### PR TITLE
Use temp files for middleware file pointer

### DIFF
--- a/django_filepicker/middleware.py
+++ b/django_filepicker/middleware.py
@@ -1,6 +1,7 @@
 import re
 import urllib2
 from django.core.files import File
+from django.core.files.temp import NamedTemporaryFile
 
 
 class URLFileMapperMiddleware(object):
@@ -29,7 +30,11 @@ class URLFileMapperMiddleware(object):
                     else:
                         name = "fp-file"
 
-                    request.FILES[key] = File(val, name=name)
+                    fp_data = NamedTemporaryFile(delete=True)
+                    fp_data.write(url_fp.read())
+                    fp_data.flush()
+
+                    request.FILES[key] = File(fp_data, name=name)
 
     def isFilepickerURL(self, val):
         return bool(self.filepicker_url_regex.match(val))


### PR DESCRIPTION
I am using Django 1.3 for ref. When I used the code, the demo site worked great. On an existing django site which uses a model form for one class and adds in an extra form field which was a FileField and is now a FPFileField I kept getting errors thrown when I would do something like:

``` python
                afile = AssetFile(
                    content=request.FILES['asset_file'],
                    asset=asset,
                    name=unicode(asset)
                )
```

I traced it back up to content. The line erroring in django was [L39 of base.py](https://github.com/django/django/blob/1.3.1/django/core/files/base.py#L39) - when it goes to read the file size using the name - the middleware was instantiating the django File object with a unicode string so I would get "unicode object has no attribute 'name'". 

Mirroring what the middleware was doing from a shell (unless I'm mistaken):

``` python
In [10]: f = File(u'http://jaymz.eu/me.jpg', name="jaymz")

In [11]: f
Out[11]: <File: jaymz>

In [12]: f.size
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-12-6a0714c5c9bb> in <module>()
----> 1 f.size

/usr/lib/python2.7/site-packages/django/core/files/base.pyc in _get_size(self)
     37             if hasattr(self.file, 'size'):
     38                 self._size = self.file.size
---> 39             elif os.path.exists(self.file.name):
     40                 self._size = os.path.getsize(self.file.name)
     41             else:

AttributeError: 'unicode' object has no attribute 'name'
```

If instead I convert within the middleware the first argument to File as a filepointer as is required (and is basically exactly what happens within forms.py#to_python) then all is good and I can carry on working with request.FILES as usual.

Given even in django 1.4 the _file_ parameter to Files is a pointer guessing this was an error(?) 

Cheers and thanks for the great service.
