### PR TITLE
Allow setting the 'fp-option-services' via a global in SETTINGS

### DIFF
--- a/django_filepicker/forms.py
+++ b/django_filepicker/forms.py
@@ -47,6 +47,9 @@ class FPFileField(forms.FileField):
                 'data-fp-mimetypes': self.mimetypes,
                 }
 
+        if hasattr(settings, 'FILEPICKER_SERVICES'):
+            attrs['data-fp-option-services'] = settings.FILEPICKER_SERVICES
+
         return attrs
 
     def to_python(self, data):


### PR DESCRIPTION
The patch checks for a global in SETTINGS called FILEPICKER_SERVICES that can be used to over-ride the default 'fp-option-services'.

I tried to follow the `if hasattr()` style used in the code currently.
