### PR TITLE
Allow configuration of filepicker.js API version

### DIFF
--- a/django_filepicker/widgets.py
+++ b/django_filepicker/widgets.py
@@ -2,14 +2,10 @@ from django.conf import settings
 from django.forms import widgets
 
 #JS_URL is the url to the filepicker.io javascript library
-JS_VERSION = 1
+JS_VERSION = getattr(settings, "FILEPICKER_JS_VERSION", 0)
 JS_URL = "//api.filepicker.io/v%d/filepicker.js" % (JS_VERSION)
 
-if hasattr(settings, 'FILEPICKER_INPUT_TYPE'):
-    INPUT_TYPE = settings.FILEPICKER_INPUT_TYPE
-else:
-    INPUT_TYPE = 'filepicker-dragdrop'
-
+INPUT_TYPE = getattr(settings, "FILEPICKER_INPUT_TYPE", "filepicker-dragdrop")
 
 class FPFileWidget(widgets.Input):
     input_type = INPUT_TYPE


### PR DESCRIPTION
Version 0 is deprecated and I want to use version 1 in my projects. However there's no way to change this without digging into the code.

Initially I was just going to fork the project, make the change and use it for ourselves (see first commit), but then I realised it might be better if I made a few more changes so it's more configurable in the future (see second commit). I've left version 0 as the default for backwards compatibility.

I also slimmed down that if statement in the same file to a simple getattr().
