### PR TITLE
Adding South introspection rule

### DIFF
--- a/django_filepicker/models.py
+++ b/django_filepicker/models.py
@@ -41,3 +41,10 @@ class FPFileField(models.FileField):
 
         defaults.update(kwargs)
         return super(FPFileField, self).formfield(**defaults)
+        
+try:
+    # For South. See: http://south.readthedocs.org/en/latest/customfields.html#extending-introspection
+    from south.modelsinspector import add_introspection_rules
+    add_introspection_rules([], ["django_filepicker\.models\.FPFileField"])
+except ImportError:
+    pass


### PR DESCRIPTION
This adds a South introspection rule so that migrations work as expected. Since this cannot depend on South, I've added a `try`/`except ImportError` and ignore it otherwise.
