### PR TITLE
updated demo project to work with django 1.6

### DIFF
--- a/demo/manage.py
+++ b/demo/manage.py
@@ -1,14 +1,8 @@
-#!/usr/bin/env python
-from django.core.management import execute_manager
-import imp
-try:
-    imp.find_module('settings') # Assumed to be in the same directory.
-except ImportError:
-    import sys
-    sys.stderr.write("Error: Can't find the file 'settings.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n" % __file__)
-    sys.exit(1)
-
-import settings
+import os, sys
 
 if __name__ == "__main__":
-    execute_manager(settings)
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)

--- a/demo/urls.py
+++ b/demo/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url, include
 
 # Uncomment the next two lines to enable the admin:
 # from django.contrib import admin


### PR DESCRIPTION
Updated the manage.py file as per https://docs.djangoproject.com/en/1.4/releases/1.4/#updated-default-project-layout-and-manage-py

urls changes since defaults has been deprecated in 1.6 https://docs.djangoproject.com/en/1.6/internals/deprecation/#id1

These changes break compatibility in 1.3 but that is unsupported. Should work >= 1.4
