### PR TITLE
Improved contributor experience by adding setuptools option to setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ demo/db.sql
 dist/
 db.sqlite3
 .DS_STORE
+build
+django_filepicker.egg-info

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,17 @@
-from distutils.core import setup
-setup(name='django-filepicker',
-      version='0.2.1',
-      description='Official Filepicker Django Library',
-      author='Filepicker.io',
-      author_email='contact@filepicker.io',
-      url='http://developers.filepicker.io/',
-      packages=['django_filepicker'],
-      install_requires=['django >= 1.3','requests']
-      )
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
+setup(
+    name='django-filepicker',
+    version='0.2.1',
+    description='Official Filepicker Django Library',
+    author='Filepicker.io',
+    author_email='contact@filepicker.io',
+    url='http://developers.filepicker.io/',
+    packages=['django_filepicker'],
+    install_requires=['django >= 1.3','requests'],
+    license="BSD",
+    zip_safe=False,
+)


### PR DESCRIPTION
- `setuptools` import option in `setup.py` means that contributors can use the very handy `python setup.py develop` option.
- Added to .gitignore to help prevent various egg building remnants from clouding up the git history
