### PR TITLE
Add FPUrlField

### DIFF
--- a/django_filepicker/models.py
+++ b/django_filepicker/models.py
@@ -5,6 +5,52 @@ try:
     from . import forms
 except ImportError:
     import forms
+    
+class FPUrlField(models.UrlField):
+    description = ugettext_lazy("A URL field for storing FilePicker.IO urls that works with the FilePicker widget")
+
+    def __init__(self, *args, **kwargs):
+        """
+        Initializes the Filepicker url field.
+        Valid arguments:
+        * apikey. This string is required if it isn't set as settings.FILEPICKER_API_KEY
+        * mimetypes. Optional, the allowed mimetypes for files. Defaults to "*/*" (all files)
+        * services. Optional, the allowed services to pull from.
+        * additional_params. Optional, additional parameters to be applied.
+        """
+        self.apikey = kwargs.pop("apikey", None)
+        self.mimetypes = kwargs.pop("mimetypes", None)
+        self.services = kwargs.pop("services", None)
+        self.additional_params=kwargs.pop("additional_params", None)
+
+        super(FPUrlField, self).__init__(*args, **kwargs)
+
+    def formfield(self, **kwargs):
+        defaults = {'form_class': forms.FPUrlField,
+                'max_length': self.max_length}
+
+        if 'initial' in kwargs:
+            defaults['required'] = False
+
+        if self.apikey:
+            defaults['apikey'] = self.apikey
+        if self.mimetypes:
+            defaults['mimetypes'] = self.mimetypes
+        if self.services:
+            defaults['services'] = self.services
+        if self.additional_params:
+            defaults['additional_params'] = self.additional_params
+
+        defaults.update(kwargs)
+        return super(FPUrlField, self).formfield(**defaults)
+        
+try:
+    # For South. See: http://south.readthedocs.org/en/latest/customfields.html#extending-introspection
+    from south.modelsinspector import add_introspection_rules
+    add_introspection_rules([], ["django_filepicker\.models\.FPUrlField"])
+except ImportError:
+    pass
+
 
 class FPFileField(models.FileField):
     description = ugettext_lazy("A File selected using Filepicker.io")


### PR DESCRIPTION
FPUrlField allows you to store the filepicker url directly and not have to deal with file object. often preferable so you don't have the overhead of downloading the file each time you want to work with just the url.
